### PR TITLE
Module ID strings can now be single quoted or double quoted strings

### DIFF
--- a/src/com/chrisfolger/needsmoredojo/core/settings/DojoSettings.java
+++ b/src/com/chrisfolger/needsmoredojo/core/settings/DojoSettings.java
@@ -30,6 +30,7 @@ public class DojoSettings implements PersistentStateComponent<DojoSettings>
     private boolean setupWarningDisabled;
     private boolean refactoringEnabled;
     private String supportedFileTypes;
+    private boolean singleQuotedModuleIDs;
     // this will be used for converting to module specific sources later
     private String version;
 
@@ -52,6 +53,7 @@ public class DojoSettings implements PersistentStateComponent<DojoSettings>
         addModuleIfThereAreNoneDefined = false;
         allowCaseInsensitiveSearch = true;
         supportedFileTypes = "jsp,js,php,html";
+        singleQuotedModuleIDs = true;
     }
 
     public @NotNull LinkedHashMap<String, String> getExceptionsMap()
@@ -184,5 +186,13 @@ public class DojoSettings implements PersistentStateComponent<DojoSettings>
 
     public void setRefactoringEnabled(boolean refactoringEnabled) {
         this.refactoringEnabled = refactoringEnabled;
+    }
+
+    public  boolean isSingleQuotedModuleIDs() {
+        return singleQuotedModuleIDs;
+    }
+
+    public void setSingleQuotedModuleIDs(boolean aSingleQuotedModuleIDs) {
+        singleQuotedModuleIDs = aSingleQuotedModuleIDs;
     }
 }

--- a/src/com/chrisfolger/needsmoredojo/intellij/actions/SendToBeginningAction.java
+++ b/src/com/chrisfolger/needsmoredojo/intellij/actions/SendToBeginningAction.java
@@ -23,12 +23,12 @@ public class SendToBeginningAction extends SendToAction
     @Override
     protected void moveAction(AnActionEvent e, PsiElement define, PsiElement parameter, List<PsiElement> defines, List<PsiElement> parameters, DefineStatement defineStatement)
     {
-        String defineText = define.getText().replaceAll("\"|'", "");
         String parameterText = parameter.getText();
 
         AMDPsiUtil.removeSingleImport(new AMDImport((JSElement) define, (JSElement) parameter));
 
-        new ImportCreator().createImport(defineText, parameterText, defineStatement.getArguments(), defineStatement.getFunction().getParameterList());
+        // define is already quoted, so passing an empty quote character
+        new ImportCreator().createImport(define.getText(), "", parameterText, defineStatement.getArguments(), defineStatement.getFunction().getParameterList());
 
         Editor editor = e.getData(PlatformDataKeys.EDITOR);
         int index = defineStatement.getArguments().getFirstChild().getTextOffset();

--- a/src/com/chrisfolger/needsmoredojo/intellij/configurable/DojoSettings.form
+++ b/src/com/chrisfolger/needsmoredojo/intellij/configurable/DojoSettings.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.chrisfolger.needsmoredojo.intellij.configurable.DojoSettingsConfigurable">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="21" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="24" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="854" height="576"/>
+      <xy x="20" y="20" width="854" height="655"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -22,7 +22,7 @@
       </component>
       <component id="ba5c8" class="javax.swing.JLabel">
         <constraints>
-          <grid row="13" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="16" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <maximum-size width="-1" height="20"/>
           </grid>
         </constraints>
@@ -32,7 +32,7 @@
       </component>
       <scrollpane id="8ea0">
         <constraints>
-          <grid row="14" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="17" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <maximum-size width="-1" height="200"/>
           </grid>
         </constraints>
@@ -50,7 +50,7 @@
       </scrollpane>
       <component id="7aefc" class="javax.swing.JTextField" binding="addModuleText">
         <constraints>
-          <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="19" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -61,7 +61,7 @@
       </component>
       <component id="66f8d" class="javax.swing.JButton" binding="addMapping">
         <constraints>
-          <grid row="16" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="19" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <icon value="general/add.png"/>
@@ -71,7 +71,7 @@
       </component>
       <component id="c3a2e" class="javax.swing.JTextField" binding="addParameterText">
         <constraints>
-          <grid row="16" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="19" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -81,7 +81,7 @@
       </component>
       <component id="b44d8" class="javax.swing.JButton" binding="removeMapping">
         <constraints>
-          <grid row="14" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="17" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <icon value="general/remove.png"/>
@@ -91,7 +91,7 @@
       </component>
       <component id="ec03" class="javax.swing.JLabel">
         <constraints>
-          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="18" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Module"/>
@@ -99,7 +99,7 @@
       </component>
       <component id="2a9d6" class="javax.swing.JLabel">
         <constraints>
-          <grid row="15" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="18" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Parameter"/>
@@ -135,7 +135,7 @@
       </component>
       <component id="d14d4" class="javax.swing.JLabel">
         <constraints>
-          <grid row="17" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="20" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Unused import exceptions:"/>
@@ -143,7 +143,7 @@
       </component>
       <scrollpane id="d3a31">
         <constraints>
-          <grid row="18" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="21" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <maximum-size width="-1" height="200"/>
           </grid>
         </constraints>
@@ -161,7 +161,7 @@
       </scrollpane>
       <component id="bcaae" class="javax.swing.JTextField" binding="addRUIExceptionModuleText">
         <constraints>
-          <grid row="20" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="23" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -172,7 +172,7 @@
       </component>
       <component id="2c20b" class="javax.swing.JButton" binding="addRUIModule">
         <constraints>
-          <grid row="20" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="23" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <icon value="general/add.png"/>
@@ -182,7 +182,7 @@
       </component>
       <component id="e923c" class="javax.swing.JTextField" binding="addRUIExceptionParameterText">
         <constraints>
-          <grid row="20" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="23" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -192,7 +192,7 @@
       </component>
       <component id="30614" class="javax.swing.JButton" binding="removeRUIModule">
         <constraints>
-          <grid row="18" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="21" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <icon value="general/remove.png"/>
@@ -202,7 +202,7 @@
       </component>
       <component id="b63ac" class="javax.swing.JLabel">
         <constraints>
-          <grid row="19" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="22" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Module"/>
@@ -210,7 +210,7 @@
       </component>
       <component id="3c474" class="javax.swing.JLabel">
         <constraints>
-          <grid row="19" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="22" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Parameter"/>
@@ -313,6 +313,32 @@
         </constraints>
         <properties>
           <text value="Enable refactoring support for move and rename file actions"/>
+        </properties>
+      </component>
+      <component id="d6b80" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Module ID Strings:"/>
+        </properties>
+      </component>
+      <component id="6e28a" class="javax.swing.JRadioButton" binding="singleQuotesRadioButton">
+        <constraints>
+          <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Single quoted (')"/>
+          <toolTipText value="Example: define(['dojo/request'], function(request){ ... });"/>
+        </properties>
+      </component>
+      <component id="b19cb" class="javax.swing.JRadioButton" binding="doubleQuotesRadioButton">
+        <constraints>
+          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Double Quoted (&quot;)"/>
+          <toolTipText value="Example: define([&quot;dojo/request&quot;], function(request){ ... });"/>
         </properties>
       </component>
     </children>

--- a/src/com/chrisfolger/needsmoredojo/intellij/configurable/DojoSettingsConfigurable.java
+++ b/src/com/chrisfolger/needsmoredojo/intellij/configurable/DojoSettingsConfigurable.java
@@ -53,6 +53,9 @@ public class DojoSettingsConfigurable implements Configurable {
     private JTextField supportedFileTypes;
     private JCheckBox displayWarningIfSourcesCheckBox;
     private JCheckBox enableRefactoringSupportForCheckBox;
+    private JRadioButton singleQuotesRadioButton;
+    private JRadioButton doubleQuotesRadioButton;
+    private ButtonGroup quotesButtonGroup;
     private Project project;
     private String dojoSourceString;
     private String projectSourceString;
@@ -147,6 +150,7 @@ public class DojoSettingsConfigurable implements Configurable {
                 allowCaseInsensitiveSearch.isSelected() != settingsService.isAllowCaseInsensitiveSearch() ||
                 !supportedFileTypes.getText().equals(settingsService.getSupportedFileTypes()) ||
                 enableRefactoringSupportForCheckBox.isSelected() != settingsService.isRefactoringEnabled() ||
+                singleQuotesRadioButton.isSelected() != settingsService.isSingleQuotedModuleIDs() ||
                 // this flag is true if it's unchecked
                 displayWarningIfSourcesCheckBox.isSelected() == settingsService.isSetupWarningDisabled();
 
@@ -277,6 +281,28 @@ public class DojoSettingsConfigurable implements Configurable {
             }
         });
 
+        quotesButtonGroup = new ButtonGroup();
+        quotesButtonGroup.add(singleQuotesRadioButton);
+        quotesButtonGroup.add(doubleQuotesRadioButton);
+
+        singleQuotesRadioButton.addActionListener( new ActionListener()
+        {
+            @Override
+            public void actionPerformed( ActionEvent e )
+            {
+                updateModifiedState();
+            }
+        } );
+
+        doubleQuotesRadioButton.addActionListener( new ActionListener()
+        {
+            @Override
+            public void actionPerformed( ActionEvent e )
+            {
+                updateModifiedState();
+            }
+        } );
+
         return myComponent;
     }
 
@@ -353,6 +379,7 @@ public class DojoSettingsConfigurable implements Configurable {
         settingsService.setSupportedFileTypes(supportedFileTypes.getText());
         settingsService.setSetupWarningDisabled(!displayWarningIfSourcesCheckBox.isSelected());
         settingsService.setRefactoringEnabled(enableRefactoringSupportForCheckBox.isSelected());
+        settingsService.setSingleQuotedModuleIDs(singleQuotesRadioButton.isSelected());
 
         modified = false;
     }
@@ -382,6 +409,11 @@ public class DojoSettingsConfigurable implements Configurable {
         supportedFileTypes.setText(settingsService.getSupportedFileTypes());
         displayWarningIfSourcesCheckBox.setSelected(!settingsService.isSetupWarningDisabled());
         enableRefactoringSupportForCheckBox.setSelected(settingsService.isRefactoringEnabled());
+        if (settingsService.isSingleQuotedModuleIDs()) {
+            singleQuotesRadioButton.setSelected(true);
+        } else {
+            doubleQuotesRadioButton.setSelected(true);
+        }
 
         modified = false;
     }


### PR DESCRIPTION
Hello Chris,

When adding AMD modules using needsmoredojo, it appears that module ID strings are always added as single quoted strings (e.g. 'dojo/sniff).  In our projects, we delimit strings (and also module IDs) with double quotes in our JavaScript projects ("dojo/sniff").  

I took the liberty to add an option to needsmoredojo where you can choose what quotes you want to use.  The pull requests adds an option (radio buttons) to the settings panel.  This option is picked up in the ImportCreator which uses the option to format the Module ID with single or double quotes.

Currently only the "Add Import" action respects the configuration option.  The "Organize AMD Imports" still replaces quotes as before (looks at the majority of the quotes used?).  The actions that move around imports leave the quotes untouched.  

I'm not sure if I changed the API to your liking, please let me know if you see things differently.  It's the first time I tinkered around with IntelliJ plugins, so it is all kind of new to me :).

Tom
